### PR TITLE
Fix scala binary version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ object MyBuild extends Build {
     version := "0.1.1",
 
     scalaVersion := "2.10.0",
-    scalaBinaryVersion := "2.10.0",
+    scalaBinaryVersion := "2.10",
 
     scalacOptions ++= Seq(
       "-Xlog-free-terms",


### PR DESCRIPTION
Remove the last digit from scala binary version, otherwise sbt will complain with the following output:

```
> update
[info] Updating {file:/Users/beat/Workbench/debox/}debox...
[warn] Binary version (2.10) for dependency org.scala-lang#scala-reflect;2.10.0
[warn]  in debox#debox_2.10.0;0.1.1 differs from Scala binary version in project (2.10.0).
[warn] Binary version (2.10) for dependency org.scala-lang#scala-library;2.10.0
[warn]  in debox#debox_2.10.0;0.1.1 differs from Scala binary version in project (2.10.0).
[info] Resolving org.scala-lang#scala-reflect;2.10.0 ...
[info] Resolving org.scala-lang#scala-library;2.10.0 ...
[info] Resolving org.scalatest#scalatest_2.10.0;1.8 ...
[info] Resolving org.scala-lang#scala-actors;2.10.0 ...
[info] Done updating.
[success] Total time: 0 s, completed Apr 10, 2013 8:50:07 PM
```
