### PR TITLE
Grow map using Map.ofAllocatedSize instead of Map.ofSize

### DIFF
--- a/src/main/scala/debox/Map.scala
+++ b/src/main/scala/debox/Map.scala
@@ -751,7 +751,7 @@ final class Map[@sp(Int, Long, AnyRef) A, @sp B] protected[debox] (ks: Array[A],
    */
   final def grow(): Unit2[A, B] = {
     val next = keys.length * (if (keys.length < 10000) 4 else 2)
-    val map = Map.ofSize[A, B](next)
+    val map = Map.ofAllocatedSize[A, B](next)
     cfor(0)(_ < buckets.length, _ + 1) { i =>
       if (buckets(i) == 3) map(keys(i)) = vals(i)
     }


### PR DESCRIPTION
This was causing confusing behaviour when adding elements to an empty Map:
```
adam-Ammonite@ val m = debox.Map.empty[Int, Int] 
m: debox.Map[Int, Int] = Map()
adam-Ammonite@ 1 to 100000 foreach (m(_) = 0) 

adam-Ammonite@ m.keys.size 
res3: Int = 524288
adam-Ammonite@ val m2 = debox.Map.ofSize[Int, Int](100000) 
m2: debox.Map[Int, Int] = Map()
adam-Ammonite@ 1 to 100000 foreach (m2(_) = 0) 

adam-Ammonite@ m2.keys.size 
res6: Int = 262144
```